### PR TITLE
Fix concatenation of keys to table header for "vector of hashmap"

### DIFF
--- a/json-to-org-table.el
+++ b/json-to-org-table.el
@@ -138,7 +138,7 @@ REF: a reference is this is a linked table"
            (consp (aref elt 0)))
       (let ((keys (mapc #'car (aref elt 0)))
             )
-        (j2t-c+ (format "|%s|\n" (string-join "" (mapc (lambda (x) (format "%s" (car x))) keys))))
+        (j2t-c+ (format "|%s|\n" (string-join (mapcar (lambda (x) (format "%s" (car x))) keys) "|")))
         (j2t-c+ "|-\n")
         (seq-map-indexed
          (lambda (elt idx)


### PR DESCRIPTION
Hello, I was having trouble with this example in the README.md:

```json
[{"type": "human", "name": "Manuel", "nickname": "Mannie"},
 {"type": "AI", "name": "HOLMES IV", "nickname": "Mike"},
 {"type": "human", "name": "Bernardo de la Paz", "nickname": "The Professor"}]
```

Instead of the expected table (with headers), I get this:

```
||
|-
|human|Manuel|Mannie|
|AI|HOLMES IV|Mike|
|human|Bernardo de la Paz|The Professor|
```

I'm running on Emacs 29.05, if that makes a difference.  This PR is a one-line change that produced the desired org table for me.  Are there any other tests to run to make sure that it still works for other use cases?

Thanks for the useful package!